### PR TITLE
Update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cycle-go-client
+module github.com/cycleplatform/api-client-go
 
 go 1.19
 


### PR DESCRIPTION
The incorrect module name was being used prior to this repo being open sourced, this corrects that.