### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "api-spec"]
 	path = api-spec
-	url = git@github.com:cycleplatform/api-spec.git
+	url = https://github.com/cycleplatform/api-spec.git


### PR DESCRIPTION
Updates the gitmodules to use http instead of ssh.  This makes it easier to interact with the submodule repo without authentication conflicts. 